### PR TITLE
fixed false name when import the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ console.log(normalize('Åland')) // Aland
 You can import it as a commonJS module
 
 ```javascript
-var n = require('normalize');
+var n = require('normalize-strings');
 
 console.log(n('Åland')) // Aland
 ```


### PR DESCRIPTION
There is a little bug in the documentation.